### PR TITLE
Fix include directory when project is added as subdirectory

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -124,7 +124,7 @@ jobs:
           -B find_package_build
 
         cmake \
-          --build find_package_build
+          --build find_package_build --verbose
 
     - name: Locate the packages (RelWithDebInfo only)
       if: matrix.build_type == 'RelWithDebInfo'

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -553,8 +553,8 @@ if(SLEIGH_ENABLE_EXAMPLES)
   )
 
   target_link_libraries(sleighexample PRIVATE
-    sla
-    decomp
+    sleigh::sla
+    sleigh::decomp
   )
 
   add_custom_target(sleighexample_runner

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -152,8 +152,14 @@ set(sleigh_slacomp_source_list
 
 add_library(sleigh_settings INTERFACE)
 add_library(sleigh::sleigh_settings ALIAS sleigh_settings)
+
 target_compile_features(sleigh_settings INTERFACE
   cxx_std_17
+)
+
+target_include_directories(
+  sleigh_settings ${warning_guard}
+  INTERFACE $<BUILD_INTERFACE:${library_root}>
 )
 
 set_target_properties(sleigh_settings PROPERTIES
@@ -567,10 +573,10 @@ if(SLEIGH_ENABLE_INSTALL)
       "${CMAKE_INSTALL_LIBDIR}"
 
     INCLUDES DESTINATION
-      include
+      ${CMAKE_INSTALL_INCLUDEDIR}/sleigh
 
     PUBLIC_HEADER DESTINATION
-      "${CMAKE_INSTALL_INCLUDEDIR}/sleigh"
+      ${CMAKE_INSTALL_INCLUDEDIR}/sleigh
 
     PERMISSIONS
       OWNER_READ OWNER_WRITE OWNER_EXECUTE
@@ -627,7 +633,11 @@ if(SLEIGH_ENABLE_INSTALL)
       ${public_include_header_list}
 
     DESTINATION
-      "${CMAKE_INSTALL_INCLUDEDIR}/sleigh"
+      ${CMAKE_INSTALL_INCLUDEDIR}/sleigh
+  )
+  target_include_directories(
+    sleigh_settings ${warning_guard}
+    INTERFACE $<INSTALL_INTERFACE:${CMAKE_INSTALL_INCLUDEDIR}/sleigh>
   )
 
   if(CMAKE_BUILD_TYPE STREQUAL "Debug")

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -31,6 +31,39 @@ if(SLEIGH_ENABLE_PACKAGING)
   endif()
 endif()
 
+set(public_include_header_list
+  "${PROJECT_SOURCE_DIR}/include/libsleigh.hh"
+  "${library_root}/address.hh"
+  "${library_root}/context.hh"
+  "${library_root}/emulate.hh"
+  "${library_root}/error.hh"
+  "${library_root}/float.hh"
+  "${library_root}/globalcontext.hh"
+  "${library_root}/loadimage.hh"
+  "${library_root}/memstate.hh"
+  "${library_root}/opbehavior.hh"
+  "${library_root}/opcodes.hh"
+  "${library_root}/partmap.hh"
+  "${library_root}/pcoderaw.hh"
+  "${library_root}/semantics.hh"
+  "${library_root}/sleigh.hh"
+  "${library_root}/sleighbase.hh"
+  "${library_root}/slghpatexpress.hh"
+  "${library_root}/slghpattern.hh"
+  "${library_root}/slghsymbol.hh"
+  "${library_root}/space.hh"
+  "${library_root}/translate.hh"
+  "${library_root}/types.h"
+  "${library_root}/xml.hh"
+)
+set(public_headers_dir ${CMAKE_CURRENT_BINARY_DIR}/include)
+file(MAKE_DIRECTORY "${public_headers_dir}/sleigh")
+# Copy the public headers into our build directory so that we can control the layout.
+# Ideally, we want to let people '#include <sleigh/{header}>' without installing sleigh
+foreach(public_header ${public_include_header_list})
+  configure_file("${public_header}" "${public_headers_dir}/sleigh" COPYONLY)
+endforeach()
+
 set(sleigh_core_source_list
   "${library_root}/xml.cc"
   "${library_root}/space.cc"
@@ -157,11 +190,6 @@ target_compile_features(sleigh_settings INTERFACE
   cxx_std_17
 )
 
-target_include_directories(
-  sleigh_settings ${warning_guard}
-  INTERFACE $<BUILD_INTERFACE:${library_root}>
-)
-
 set_target_properties(sleigh_settings PROPERTIES
   INTERFACE_POSITION_INDEPENDENT_CODE ON
 )
@@ -245,6 +273,7 @@ target_compile_definitions(decomp_opt PRIVATE
 target_link_libraries(decomp_opt PRIVATE
   sleigh::sleigh_settings
 )
+target_include_directories(decomp_opt PRIVATE $<BUILD_INTERFACE:${library_root}>)
 
 if(CMAKE_BUILD_TYPE STREQUAL "Debug")
   target_compile_definitions(decomp_opt PRIVATE
@@ -280,13 +309,10 @@ if(SLEIGH_ENABLE_TESTS)
   target_link_libraries(ghidra_test_dbg PRIVATE
     sleigh::sleigh_settings
   )
+  target_include_directories(ghidra_test_dbg PRIVATE $<BUILD_INTERFACE:${library_root}>)
 
   target_compile_definitions(ghidra_test_dbg PRIVATE
     __TERMINAL__
-  )
-
-  target_include_directories(ghidra_test_dbg PRIVATE
-    "${library_root}"
   )
 
   set(extra_test_args "")
@@ -321,6 +347,7 @@ endif()
 target_link_libraries(ghidra_opt PRIVATE
   sleigh::sleigh_settings
 )
+target_include_directories(ghidra_opt PRIVATE $<BUILD_INTERFACE:${library_root}>)
 
 if(CMAKE_BUILD_TYPE STREQUAL "Debug")
   target_sources(ghidra_opt PRIVATE
@@ -353,6 +380,7 @@ add_executable(sleigh::sleigh_opt ALIAS sleigh_opt)
 target_link_libraries(sleigh_opt PRIVATE
   sleigh::sleigh_settings
 )
+target_include_directories(sleigh_opt PRIVATE $<BUILD_INTERFACE:${library_root}>)
 
 if(CMAKE_BUILD_TYPE STREQUAL "Debug")
   set_target_properties(sleigh_opt PROPERTIES
@@ -379,6 +407,13 @@ add_library(sleigh::sla ALIAS sla)
 target_link_libraries(sla PUBLIC
   sleigh::sleigh_settings
 )
+# Private include search path '#include "..."
+target_include_directories(sla PRIVATE $<BUILD_INTERFACE:${library_root}>)
+# Public include search path in build directory
+target_include_directories(
+  sla SYSTEM
+  INTERFACE $<BUILD_INTERFACE:${public_headers_dir}>
+)
 
 if(CMAKE_BUILD_TYPE STREQUAL "Debug")
   target_compile_definitions(sla PRIVATE
@@ -404,6 +439,13 @@ add_library(sleigh::decomp ALIAS decomp)
 
 target_link_libraries(decomp PUBLIC
   sleigh::sleigh_settings
+)
+# Private include search path '#include "..."
+target_include_directories(decomp PRIVATE $<BUILD_INTERFACE:${library_root}>)
+# Public include search path in build directory
+target_include_directories(
+  decomp SYSTEM
+  INTERFACE $<BUILD_INTERFACE:${public_headers_dir}>
 )
 
 if(CMAKE_BUILD_TYPE STREQUAL "Debug")
@@ -562,6 +604,14 @@ if(SLEIGH_ENABLE_INSTALL)
   )
 
   install(
+    FILES
+    ${public_include_header_list}
+
+    DESTINATION
+    ${CMAKE_INSTALL_INCLUDEDIR}/sleigh
+  )
+
+  install(
     TARGETS
       sla
       decomp
@@ -573,10 +623,10 @@ if(SLEIGH_ENABLE_INSTALL)
       "${CMAKE_INSTALL_LIBDIR}"
 
     INCLUDES DESTINATION
-      ${CMAKE_INSTALL_INCLUDEDIR}/sleigh
+      ${CMAKE_INSTALL_INCLUDEDIR}
 
     PUBLIC_HEADER DESTINATION
-      ${CMAKE_INSTALL_INCLUDEDIR}/sleigh
+      ${CMAKE_INSTALL_INCLUDEDIR}
 
     PERMISSIONS
       OWNER_READ OWNER_WRITE OWNER_EXECUTE
@@ -600,44 +650,6 @@ if(SLEIGH_ENABLE_INSTALL)
 
     DESTINATION
       "${CMAKE_INSTALL_DOCDIR}"
-  )
-
-  set(public_include_header_list
-    "${library_root}/address.hh"
-    "${library_root}/context.hh"
-    "${library_root}/emulate.hh"
-    "${library_root}/error.hh"
-    "${library_root}/float.hh"
-    "${library_root}/globalcontext.hh"
-    "${library_root}/loadimage.hh"
-    "${library_root}/memstate.hh"
-    "${library_root}/opbehavior.hh"
-    "${library_root}/opcodes.hh"
-    "${library_root}/partmap.hh"
-    "${library_root}/pcoderaw.hh"
-    "${library_root}/semantics.hh"
-    "${library_root}/sleighbase.hh"
-    "${library_root}/sleigh.hh"
-    "${library_root}/slghpatexpress.hh"
-    "${library_root}/slghpattern.hh"
-    "${library_root}/slghsymbol.hh"
-    "${library_root}/space.hh"
-    "${library_root}/translate.hh"
-    "${library_root}/types.h"
-    "${library_root}/xml.hh"
-    "${PROJECT_SOURCE_DIR}/include/libsleigh.hh"
-  )
-
-  install(
-    FILES
-      ${public_include_header_list}
-
-    DESTINATION
-      ${CMAKE_INSTALL_INCLUDEDIR}/sleigh
-  )
-  target_include_directories(
-    sleigh_settings ${warning_guard}
-    INTERFACE $<INSTALL_INTERFACE:${CMAKE_INSTALL_INCLUDEDIR}/sleigh>
   )
 
   if(CMAKE_BUILD_TYPE STREQUAL "Debug")

--- a/cmake/options.cmake
+++ b/cmake/options.cmake
@@ -30,3 +30,22 @@ endif()
 if(SLEIGH_ENABLE_INSTALL)
   set(SLEIGH_ENABLE_DOCUMENTATION true CACHE BOOL "Set to true to enable the documentation (forced)" FORCE)
 endif()
+
+
+# ---- Warning guard ----
+
+# target_include_directories with the SYSTEM modifier will request the compiler
+# to omit warnings from the provided paths, if the compiler supports that
+# This is to provide a user experience similar to find_package when
+# add_subdirectory or FetchContent is used to consume this project
+set(warning_guard "")
+if(NOT PROJECT_IS_TOP_LEVEL)
+  option(SLEIGH_INCLUDES_WITH_SYSTEM
+    "Use SYSTEM modifier for sleigh's includes, disabling warnings"
+    ON
+  )
+  mark_as_advanced(SLEIGH_INCLUDES_WITH_SYSTEM)
+  if(SLEIGH_INCLUDES_WITH_SYSTEM)
+    set(warning_guard SYSTEM)
+  endif()
+endif()

--- a/cmake/packaging.cmake
+++ b/cmake/packaging.cmake
@@ -6,7 +6,7 @@
 # the LICENSE file found in the root directory of this source tree.
 #
 
-set(PACKAGE_VERSION 1)
+set(PACKAGE_VERSION 2)
 if("${SLEIGH_GHIDRA_RELEASE_TYPE}" STREQUAL "HEAD")
   set(PACKAGE_VERSION "DEV.${ghidra_short_commit}")
 endif()

--- a/cmake/packaging.cmake
+++ b/cmake/packaging.cmake
@@ -6,7 +6,7 @@
 # the LICENSE file found in the root directory of this source tree.
 #
 
-set(PACKAGE_VERSION 2)
+set(PACKAGE_VERSION 3)
 if("${SLEIGH_GHIDRA_RELEASE_TYPE}" STREQUAL "HEAD")
   set(PACKAGE_VERSION "DEV.${ghidra_short_commit}")
 endif()

--- a/tests/find_package/src/main.cpp
+++ b/tests/find_package/src/main.cpp
@@ -6,6 +6,6 @@
   the LICENSE file found in the root directory of this source tree.
 */
 
-#include <libsleigh.hh>
+#include <sleigh/libsleigh.hh>
 
 int main() { return 0; }

--- a/tests/find_package/src/main.cpp
+++ b/tests/find_package/src/main.cpp
@@ -6,6 +6,6 @@
   the LICENSE file found in the root directory of this source tree.
 */
 
-#include <sleigh/libsleigh.hh>
+#include <libsleigh.hh>
 
 int main() { return 0; }

--- a/tools/sleigh-lift/CMakeLists.txt
+++ b/tools/sleigh-lift/CMakeLists.txt
@@ -26,11 +26,6 @@ if(CMAKE_BUILD_TYPE STREQUAL "Debug")
   endif()
 endif()
 
-target_include_directories(sleigh-lift PRIVATE
-  "${library_root}"
-  "${PROJECT_SOURCE_DIR}/include"
-)
-
 target_link_libraries(sleigh-lift PRIVATE
   sleigh::sla
   sleigh::decomp

--- a/tools/sleigh-lift/src/main.cpp
+++ b/tools/sleigh-lift/src/main.cpp
@@ -6,7 +6,7 @@
   the LICENSE file found in the root directory of this source tree.
 */
 
-#include <libsleigh.hh>
+#include <sleigh/libsleigh.hh>
 
 #include <cassert>
 #include <iostream>


### PR DESCRIPTION
Fix the include directories and allow someone to use this project with CMake's `add_subdirectory` or with FetchContent.

**Below text was original description and fixed in https://github.com/lifting-bits/sleigh/pull/17/commits/809056a33779454681a0b7da62592b29d8fcae96**

The `sleigh/` prefix would be nice to use, but I believe it's impossible for source code to support different include-directory structures in the build and install interfaces.

This issue happens when you want to support including this project using both CMake's `add_subdirectory` and `find_package`.

Maybe I'm missing something though.