### PR TITLE
Add source-only custom target for header files

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -56,6 +56,8 @@ set(public_include_header_list
   "${library_root}/types.h"
   "${library_root}/xml.hh"
 )
+# Create custom target so that IDEs know these files are part of the sources
+add_custom_target(sleigh_all_headers SOURCES ${public_include_header_list})
 set(public_headers_dir ${CMAKE_CURRENT_BINARY_DIR}/include)
 file(MAKE_DIRECTORY "${public_headers_dir}/sleigh")
 # Copy the public headers into our build directory so that we can control the layout.


### PR DESCRIPTION
This target doesn't actually build or do anything---it just helps IDEs
identify all source files.

For instance, CLion highlights source files differently depending on
whether or not they are explicitly listed as a source file in the
CMakeLists.txt. This can also help identify whether the header file you
navigated to was a copied one (in the build directory to support the
include <sleigh/*> prefix) or the real one under source control.

See the `SOURCES` documentation on this page for more info https://cmake.org/cmake/help/latest/command/add_custom_target.html?highlight=add_custom_target