### PR TITLE
Remove SLEIGH_ENABLE_INSTALL and use CMake variable

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -597,7 +597,7 @@ add_subdirectory(support)
 # Install targets
 #
 
-if(SLEIGH_ENABLE_INSTALL)
+if(NOT CMAKE_SKIP_INSTALL_RULES)
   include("GNUInstallDirs")
 
   install(

--- a/README.md
+++ b/README.md
@@ -40,8 +40,7 @@ git clone https://github.com/lifting-bits/sleigh.git
 cd sleigh
 
 # Configure CMake
-cmake -B build -S . \
-    -DSLEIGH_ENABLE_INSTALL=ON
+cmake -B build -S .
 
 # Build SLEIGH
 cmake --build build -j

--- a/cmake/options.cmake
+++ b/cmake/options.cmake
@@ -8,7 +8,6 @@
 
 option(SLEIGH_ENABLE_TESTS "Set to true to enable tests" ON)
 option(SLEIGH_ENABLE_EXAMPLES "Set to true to build examples" ON)
-option(SLEIGH_ENABLE_INSTALL "Set to true to enable the install directives")
 option(SLEIGH_ENABLE_DOCUMENTATION "Set to true to enable the documentation")
 option(SLEIGH_ENABLE_PACKAGING "Set to true to enable packaging")
 option(SLEIGH_ENABLE_SANITIZERS "Set to true to enable sanitizers")
@@ -22,11 +21,6 @@ option(SLEIGH_DFSVERIFY_DEBUG "Make sure that the block ordering algorithm produ
 # Additional internal settings
 option(SLEIGH_CPUI_STATISTICS "Turn on collection of cover and cast statistics")
 option(SLEIGH_CPUI_RULECOMPILE "Allow user defined dynamic rules")
-
-if(SLEIGH_ENABLE_PACKAGING)
-  set(SLEIGH_ENABLE_INSTALL true CACHE BOOL "Set to true to enable the install directives (forced)" FORCE)
-endif()
-
 
 # ---- Warning guard ----
 

--- a/tools/sleigh-lift/CMakeLists.txt
+++ b/tools/sleigh-lift/CMakeLists.txt
@@ -32,7 +32,7 @@ target_link_libraries(sleigh-lift PRIVATE
   sleigh::support
 )
 
-if(SLEIGH_ENABLE_INSTALL)
+if(NOT CMAKE_SKIP_INSTALL_RULES)
   install(
     TARGETS
       sleigh-lift


### PR DESCRIPTION
Create installation rules by default.

Is there a reason I'm missing why we need a project-specific variable to control this?