### PR TITLE
Expose specfile directory in installed sleighConfig

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -715,16 +715,43 @@ if(NOT CMAKE_SKIP_INSTALL_RULES)
     endforeach()
   endif()
 
+  set(
+    sleigh_INSTALL_CMAKEDIR "${CMAKE_INSTALL_LIBDIR}/cmake/sleigh"
+    CACHE PATH "CMake package config location relative to the install prefix"
+  )
+  mark_as_advanced(sleigh_INSTALL_CMAKEDIR)
+
   install(
     EXPORT sleighTargets
-    DESTINATION "${CMAKE_INSTALL_LIBDIR}/cmake/sleigh"
+    DESTINATION "${sleigh_INSTALL_CMAKEDIR}"
     NAMESPACE sleigh::
   )
 
+  # Specfiles installation setup
+  set(
+    sleigh_INSTALL_DATADIR "${CMAKE_INSTALL_DATADIR}/sleigh"
+    CACHE PATH "sleigh data installation location relative to the install prefix"
+  )
+  mark_as_advanced(sleigh_INSTALL_DATADIR)
+
+  set(sleigh_INSTALL_SPECDIR "${sleigh_INSTALL_DATADIR}/specfiles"
+    CACHE PATH "sleigh specfile root destination relative to the install prefix"
+  )
+  mark_as_advanced(sleigh_INSTALL_SPECDIR)
+
+  include(CMakePackageConfigHelpers)
+
+  configure_package_config_file(cmake/install-config.cmake.in
+    ${PROJECT_BINARY_DIR}/install-config.cmake
+    INSTALL_DESTINATION "${sleigh_INSTALL_CMAKEDIR}"
+    NO_CHECK_REQUIRED_COMPONENTS_MACRO
+    PATH_VARS sleigh_INSTALL_SPECDIR
+  )
+
   install(
-    FILES cmake/install-config.cmake
-    DESTINATION "${CMAKE_INSTALL_LIBDIR}/cmake/sleigh"
-    RENAME "sleighConfig.cmake"
+    FILES ${PROJECT_BINARY_DIR}/install-config.cmake
+    RENAME sleighConfig.cmake
+    DESTINATION "${sleigh_INSTALL_CMAKEDIR}"
   )
 endif()
 

--- a/cmake/install-config.cmake
+++ b/cmake/install-config.cmake
@@ -1,1 +1,0 @@
-include("${CMAKE_CURRENT_LIST_DIR}/sleighTargets.cmake")

--- a/cmake/install-config.cmake.in
+++ b/cmake/install-config.cmake.in
@@ -1,0 +1,6 @@
+@PACKAGE_INIT@
+
+include("${CMAKE_CURRENT_LIST_DIR}/sleighTargets.cmake")
+
+# Path relative-root to reach installed specfiles directory
+set_and_check(SLEIGH_INSTALL_SPECDIR "@PACKAGE_sleigh_INSTALL_SPECDIR@")

--- a/cmake/packaging.cmake
+++ b/cmake/packaging.cmake
@@ -6,7 +6,7 @@
 # the LICENSE file found in the root directory of this source tree.
 #
 
-set(PACKAGE_VERSION 1)
+set(PACKAGE_VERSION 2)
 if("${SLEIGH_GHIDRA_RELEASE_TYPE}" STREQUAL "HEAD")
   set(PACKAGE_VERSION "DEV.${ghidra_short_commit}")
 endif()


### PR DESCRIPTION
Let's users know where the currently installed set of specfiles are
located. This path shouldn't be compiled into any binaries that you want
to distribute in a relocatable manner because the path probably won't
exist on another computer.