### PR TITLE
Consistent CMake project variable names - project name case

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -101,11 +101,11 @@ jobs:
           -DCMAKE_CXX_COMPILER_LAUNCHER=ccache \
           -DCMAKE_C_COMPILER_LAUNCHER=ccache \
           -DCMAKE_BUILD_TYPE=${{ matrix.build_type }} \
-          -DSLEIGH_GHIDRA_RELEASE_TYPE=${{ matrix.release }} \
-          -DSLEIGH_ENABLE_TESTS=ON \
-          -DSLEIGH_ENABLE_EXAMPLES=ON \
-          -DSLEIGH_ENABLE_PACKAGING=ON \
-          -DSLEIGH_ENABLE_DOCUMENTATION=ON
+          -Dsleigh_GHIDRA_RELEASE_TYPE=${{ matrix.release }} \
+          -Dsleigh_ENABLE_TESTS=ON \
+          -Dsleigh_ENABLE_EXAMPLES=ON \
+          -Dsleigh_ENABLE_PACKAGING=ON \
+          -Dsleigh_ENABLE_DOCUMENTATION=ON
 
     - name: Build the project
       run: |

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -19,11 +19,11 @@ project("sleigh"
 
 include("cmake/options.cmake")
 
-if(SLEIGH_ENABLE_TESTS)
+if(sleigh_ENABLE_TESTS)
   include("CTest")
 endif()
 
-if(SLEIGH_ENABLE_PACKAGING)
+if(sleigh_ENABLE_PACKAGING)
   include("cmake/packaging.cmake")
 
   if(CMAKE_BUILD_TYPE STREQUAL "Debug")
@@ -194,14 +194,14 @@ target_compile_features(sleigh_settings INTERFACE
   cxx_std_17
 )
 
-set(SLEIGH_SPEC_INSTALL_DIR "${CMAKE_INSTALL_PREFIX}/share/sleigh/specfiles/")
-set(SLEIGH_SPEC_BUILD_DIR "${CMAKE_CURRENT_BINARY_DIR}/specfiles/")
+set(sleigh_SPEC_INSTALL_DIR "${CMAKE_INSTALL_PREFIX}/share/sleigh/specfiles/")
+set(sleigh_SPEC_BUILD_DIR "${CMAKE_CURRENT_BINARY_DIR}/specfiles/")
 
 set_target_properties(sleigh_settings PROPERTIES
   INTERFACE_POSITION_INDEPENDENT_CODE ON
 )
 
-if(SLEIGH_ENABLE_SANITIZERS)
+if(sleigh_ENABLE_SANITIZERS)
   message(STATUS "sleigh: Sanitizers have been enabled")
 
   if(NOT CMAKE_BUILD_TYPE STREQUAL "Debug")
@@ -225,11 +225,11 @@ if(CMAKE_BUILD_TYPE STREQUAL "Debug")
   )
 
   foreach(debug_setting ${debug_setting_list})
-    if(NOT SLEIGH_${debug_setting})
+    if(NOT sleigh_${debug_setting})
       continue()
     endif()
 
-    message(STATUS "sleigh: Enabling debug setting: SLEIGH_${debug_setting}")
+    message(STATUS "sleigh: Enabling debug setting: sleigh_${debug_setting}")
 
     target_compile_definitions(sleigh_settings INTERFACE
       ${debug_setting}
@@ -243,11 +243,11 @@ set(internal_setting_list
 )
 
 foreach(internal_setting ${internal_setting_list})
-  if(NOT SLEIGH_${internal_setting})
+  if(NOT sleigh_${internal_setting})
     continue()
   endif()
 
-  message(STATUS "sleigh: Enabling internal setting: SLEIGH_${internal_setting}")
+  message(STATUS "sleigh: Enabling internal setting: sleigh_${internal_setting}")
 
   target_compile_definitions(sleigh_settings INTERFACE
     ${internal_setting}
@@ -291,7 +291,7 @@ endif()
 # ghidra_test_dbg
 #
 
-if(SLEIGH_ENABLE_TESTS)
+if(sleigh_ENABLE_TESTS)
   add_executable(ghidra_test_dbg
     ${sleigh_core_source_list}
     ${sleigh_deccore_source_list}
@@ -446,7 +446,7 @@ endif()
 # Documentation
 #
 
-if(SLEIGH_ENABLE_DOCUMENTATION)
+if(sleigh_ENABLE_DOCUMENTATION)
   message(STATUS "sleigh: Documentation has been enabled")
 
   find_package(Doxygen REQUIRED COMPONENTS dot)
@@ -467,7 +467,7 @@ endif()
 # Spec files
 #
 # Sets 'spec_file_list' variable
-if(NOT "${SLEIGH_GHIDRA_RELEASE_TYPE}" STREQUAL "HEAD")
+if(NOT "${sleigh_GHIDRA_RELEASE_TYPE}" STREQUAL "HEAD")
   include(spec-files-list/spec_files_stable.cmake)
 else()
   include(spec-files-list/spec_files_HEAD.cmake)
@@ -568,7 +568,7 @@ add_custom_target(sleigh_all_sla_specs ALL DEPENDS
 # Examples
 #
 
-if(SLEIGH_ENABLE_EXAMPLES)
+if(sleigh_ENABLE_EXAMPLES)
   add_executable(sleighexample
     "${library_root}/sleighexample.cc"
   )
@@ -639,7 +639,7 @@ if(NOT CMAKE_SKIP_INSTALL_RULES)
 
   set(CMAKE_INSTALL_DOCDIR "${CMAKE_INSTALL_DATAROOTDIR}/doc/sleigh")
 
-  if(SLEIGH_ENABLE_DOCUMENTATION)
+  if(sleigh_ENABLE_DOCUMENTATION)
     # Build docs during install
     install(CODE
       "execute_process(
@@ -654,7 +654,7 @@ if(NOT CMAKE_SKIP_INSTALL_RULES)
       DESTINATION
         "${CMAKE_INSTALL_DOCDIR}"
     )
-  endif(SLEIGH_ENABLE_DOCUMENTATION)
+  endif(sleigh_ENABLE_DOCUMENTATION)
 
   if(CMAKE_BUILD_TYPE STREQUAL "Debug")
     set(output_folder_path "${CMAKE_CURRENT_BINARY_DIR}/symlinks")

--- a/README.md
+++ b/README.md
@@ -57,13 +57,13 @@ Please see [`src/README.md`](./src/README.md) for more information on how to cus
 
 ## Packaging
 
-The CMake configuration also supports building packages for SLEIGH. If the `SLEIGH_ENABLE_PACKAGING` option is set during the configuration step, the build step will generate a tarball containing the SLEIGH installation. Additionally, the build will create an RPM package if it finds `rpm` in the `PATH` and/or a DEB package if it finds `dpkg` in the `PATH`.
+The CMake configuration also supports building packages for SLEIGH. If the `sleigh_ENABLE_PACKAGING` option is set during the configuration step, the build step will generate a tarball containing the SLEIGH installation. Additionally, the build will create an RPM package if it finds `rpm` in the `PATH` and/or a DEB package if it finds `dpkg` in the `PATH`.
 
 For example:
 
 ```sh
 cmake -B build -S . \
-    -DSLEIGH_ENABLE_PACKAGING=ON
+    -Dsleigh_ENABLE_PACKAGING=ON
 
 # Build SLEIGH
 cmake --build build -j
@@ -102,7 +102,7 @@ $ sleigh-lift pcode x86-64.sla 4881ecc00f0000
 (register,0x202,1) = INT_EQUAL (unique,0x12d00,1) (const,0x0,1)
 ```
 
-The `SLEIGH_ENABLE_EXAMPLES` option must be set to `ON` during the configuration step in order to build `sleigh-lift`.
+The `sleigh_ENABLE_EXAMPLES` option must be set to `ON` during the configuration step in order to build `sleigh-lift`.
 
 ## Helpers
 

--- a/README.md
+++ b/README.md
@@ -125,7 +125,7 @@ An example of how to use the CMake package config file can be found in the [find
 
 We also provide a CMake helper function [`sleigh_compile`](cmake/modules/sleighCompile.cmake) to compile your own `.slaspec` files using the installed sleigh compiler from this project.
 
-Lastly, the installed compiled sleigh files can be located through the CMake variable `SLEIGH_INSTALL_SPECDIR`, which is an absolute path to the root directory for where the compiled sleigh files are located---you should manually inspect this to know what to expect.
+Lastly, the installed compiled sleigh files can be located through the CMake variable `sleigh_INSTALL_SPECDIR`, which is an absolute path to the root directory for where the compiled sleigh files are located---you should manually inspect this to know what to expect.
 
 Referencing the [CMake config file](cmake/install-config.cmake.in) is also suggested for learning more about the exposed CMake variables and modules.
 

--- a/cmake/install-config.cmake.in
+++ b/cmake/install-config.cmake.in
@@ -3,4 +3,4 @@
 include("${CMAKE_CURRENT_LIST_DIR}/sleighTargets.cmake")
 
 # Path relative-root to reach installed specfiles directory
-set_and_check(SLEIGH_INSTALL_SPECDIR "@PACKAGE_sleigh_INSTALL_SPECDIR@")
+set_and_check(sleigh_INSTALL_SPECDIR "@PACKAGE_sleigh_INSTALL_SPECDIR@")

--- a/cmake/options.cmake
+++ b/cmake/options.cmake
@@ -6,21 +6,21 @@
 # the LICENSE file found in the root directory of this source tree.
 #
 
-option(SLEIGH_ENABLE_TESTS "Set to true to enable tests" ON)
-option(SLEIGH_ENABLE_EXAMPLES "Set to true to build examples" ON)
-option(SLEIGH_ENABLE_DOCUMENTATION "Set to true to enable the documentation")
-option(SLEIGH_ENABLE_PACKAGING "Set to true to enable packaging")
-option(SLEIGH_ENABLE_SANITIZERS "Set to true to enable sanitizers")
+option(sleigh_ENABLE_TESTS "Set to true to enable tests" ON)
+option(sleigh_ENABLE_EXAMPLES "Set to true to build examples" ON)
+option(sleigh_ENABLE_DOCUMENTATION "Set to true to enable the documentation")
+option(sleigh_ENABLE_PACKAGING "Set to true to enable packaging")
+option(sleigh_ENABLE_SANITIZERS "Set to true to enable sanitizers")
 
 # Internal debug settings
-option(SLEIGH_OPACTION_DEBUG "Turns on all the action tracing facilities")
-option(SLEIGH_MERGEMULTI_DEBUG "Check for MULTIEQUAL and INDIRECT intersections")
-option(SLEIGH_BLOCKCONSISTENT_DEBUG "Check that block graph structure is consistent")
-option(SLEIGH_DFSVERIFY_DEBUG "Make sure that the block ordering algorithm produces a true depth first traversal of the dominator tree")
+option(sleigh_OPACTION_DEBUG "Turns on all the action tracing facilities")
+option(sleigh_MERGEMULTI_DEBUG "Check for MULTIEQUAL and INDIRECT intersections")
+option(sleigh_BLOCKCONSISTENT_DEBUG "Check that block graph structure is consistent")
+option(sleigh_DFSVERIFY_DEBUG "Make sure that the block ordering algorithm produces a true depth first traversal of the dominator tree")
 
 # Additional internal settings
-option(SLEIGH_CPUI_STATISTICS "Turn on collection of cover and cast statistics")
-option(SLEIGH_CPUI_RULECOMPILE "Allow user defined dynamic rules")
+option(sleigh_CPUI_STATISTICS "Turn on collection of cover and cast statistics")
+option(sleigh_CPUI_RULECOMPILE "Allow user defined dynamic rules")
 
 # ---- Warning guard ----
 
@@ -30,12 +30,12 @@ option(SLEIGH_CPUI_RULECOMPILE "Allow user defined dynamic rules")
 # add_subdirectory or FetchContent is used to consume this project
 set(warning_guard "")
 if(NOT PROJECT_IS_TOP_LEVEL)
-  option(SLEIGH_INCLUDES_WITH_SYSTEM
+  option(sleigh_INCLUDES_WITH_SYSTEM
     "Use SYSTEM modifier for sleigh's includes, disabling warnings"
     ON
   )
-  mark_as_advanced(SLEIGH_INCLUDES_WITH_SYSTEM)
-  if(SLEIGH_INCLUDES_WITH_SYSTEM)
+  mark_as_advanced(sleigh_INCLUDES_WITH_SYSTEM)
+  if(sleigh_INCLUDES_WITH_SYSTEM)
     set(warning_guard SYSTEM)
   endif()
 endif()

--- a/cmake/packaging.cmake
+++ b/cmake/packaging.cmake
@@ -7,7 +7,7 @@
 #
 
 set(PACKAGE_VERSION 1)
-if("${SLEIGH_GHIDRA_RELEASE_TYPE}" STREQUAL "HEAD")
+if("${sleigh_GHIDRA_RELEASE_TYPE}" STREQUAL "HEAD")
   set(PACKAGE_VERSION "DEV.${ghidra_short_commit}")
 endif()
 

--- a/src/README.md
+++ b/src/README.md
@@ -2,9 +2,9 @@
 
 This project uses CMake's [FetchContent](https://cmake.org/cmake/help/latest/module/FetchContent.html) module to set up the Ghidra source tree. This means we can apply [patches](../patches) that live only in this repo for small changes to features like packaging or running tests.
 
-By default, CMake pulls a stable version of Ghidra. You may use a more recent commit by specifying `-DSLEIGH_GHIDRA_RELEASE_TYPE=HEAD` during CMake configuration.
+By default, CMake pulls a stable version of Ghidra. You may use a more recent commit by specifying `-Dsleigh_GHIDRA_RELEASE_TYPE=HEAD` during CMake configuration.
 
-See the `SLEIGH_GHIDRA_*` CMake cache variable comments for more details on how to customize your Ghidra source checkout.
+See the `sleigh_GHIDRA_*` CMake cache variable comments for more details on how to customize your Ghidra source checkout.
 
 ## Advanced Usage Notes
 
@@ -18,7 +18,7 @@ This method is useful for developing new features on top of the latest commits i
 
 If you want to use your own Ghidra source checkout, then set the following during CMake configuration:
 
-* `-DSLEIGH_GHIDRA_RELEASE_TYPE=HEAD` if using commits on Ghidra's default branch (`master`) or any branch that may be incompatible with the current stable version.
+* `-Dsleigh_GHIDRA_RELEASE_TYPE=HEAD` if using commits on Ghidra's default branch (`master`) or any branch that may be incompatible with the current stable version.
 
 * `-DFETCHCONTENT_SOURCE_DIR_GHIDRASOURCE=<path to your own Ghidra source>`. Remember, no existing [patches](../patches/HEAD) will be applied to your own source directory.
 
@@ -26,13 +26,13 @@ If you want to use your own Ghidra source checkout, then set the following durin
 git clone https://github.com/NationalSecurityAgency/ghidra src/ghidra
 
 cmake -B build-dev-head -S . \
-  -DSLEIGH_GHIDRA_RELEASE_TYPE=HEAD \
+  -Dsleigh_GHIDRA_RELEASE_TYPE=HEAD \
   -DFETCHCONTENT_SOURCE_DIR_GHIDRASOURCE="$(pwd)/src/ghidra"
 ```
 
 ### Reusing Downloaded Ghidra Source
 
-If you want to share a single Ghidra source checkout/clone for multiple build directories, the [_FetchContent Base Directory_](https://cmake.org/cmake/help/latest/module/FetchContent.html#variable:FETCHCONTENT_BASE_DIR) (`FETCHCONTENT_BASE_DIR`) should encode the build generator name and be located outside of the build directory (the name would look something like `cmake_fc_ghidra_${SLEIGH_GHIDRA_RELEASE_TYPE}_${CMAKE_GENERATOR}`).
+If you want to share a single Ghidra source checkout/clone for multiple build directories, the [_FetchContent Base Directory_](https://cmake.org/cmake/help/latest/module/FetchContent.html#variable:FETCHCONTENT_BASE_DIR) (`FETCHCONTENT_BASE_DIR`) should encode the build generator name and be located outside of the build directory (the name would look something like `cmake_fc_ghidra_${sleigh_GHIDRA_RELEASE_TYPE}_${CMAKE_GENERATOR}`).
 
 Initially, this means that every new build generator used for building the project will have to re-download the ghidra source tree, but any subsequent run with an already-initialize generator should be faster and skip the download.
 
@@ -93,13 +93,13 @@ The above also works when using `HEAD` commit of Ghidra.
 ```bash
 $ cmake -B build-head-release -S . -G Ninja \
     -DCMAKE_BUILD_TYPE=Release \
-    -DSLEIGH_GHIDRA_RELEASE_TYPE=HEAD \
+    -Dsleigh_GHIDRA_RELEASE_TYPE=HEAD \
     -DFETCHCONTENT_BASE_DIR=./src/cmake_fc_ghidra_HEAD_Ninja
 ...
 
 $ cmake -B build-head-debug -S . -G Ninja \
     -DCMAKE_BUILD_TYPE=Debug \
-    -DSLEIGH_GHIDRA_RELEASE_TYPE=HEAD \
+    -Dsleigh_GHIDRA_RELEASE_TYPE=HEAD \
     -DFETCHCONTENT_BASE_DIR=./src/cmake_fc_ghidra_HEAD_Ninja
 ...
 ```

--- a/src/setup-ghidra-source.cmake
+++ b/src/setup-ghidra-source.cmake
@@ -1,11 +1,11 @@
 # ---- Setup Ghidra Source code ----
 
 # Set up Ghidra repo human-readable version settings
-set(SLEIGH_GHIDRA_RELEASE_TYPE "stable" CACHE
+set(sleigh_GHIDRA_RELEASE_TYPE "stable" CACHE
   STRING "Ghidra release type to use. 'HEAD' is used for active development purposes."
 )
 # This is just helper for CMake UIs. CMake does not enforce that the value matches one of those listed.
-set_property(CACHE SLEIGH_GHIDRA_RELEASE_TYPE PROPERTY STRINGS "stable" "HEAD")
+set_property(CACHE sleigh_GHIDRA_RELEASE_TYPE PROPERTY STRINGS "stable" "HEAD")
 
 # **** Setup pinned git info ****
 
@@ -19,7 +19,7 @@ set(ghidra_patches
 )
 
 # Ghidra pinned commits used for pinning last known working HEAD commit
-if("${SLEIGH_GHIDRA_RELEASE_TYPE}" STREQUAL HEAD)
+if("${sleigh_GHIDRA_RELEASE_TYPE}" STREQUAL HEAD)
   # TODO: Try to remember to look at Ghidra/application.properties
   # TODO: CMake only likes numeric characters in the version string....
   set(ghidra_head_version "10.2")

--- a/support/GhidraVersion.cpp.in
+++ b/support/GhidraVersion.cpp.in
@@ -15,7 +15,7 @@ std::string_view GetGhidraVersion(void) { return "@ghidra_version@"; }
 std::string_view GetGhidraCommitHash(void) { return "@ghidra_git_tag@"; }
 
 std::string_view GetGhidraReleaseType(void) {
-  return "@SLEIGH_GHIDRA_RELEASE_TYPE@";
+  return "@sleigh_GHIDRA_RELEASE_TYPE@";
 }
 
 } // namespace sleigh

--- a/support/SpecFilePaths.h.in
+++ b/support/SpecFilePaths.h.in
@@ -10,7 +10,7 @@
 
 namespace sleigh {
 
-static const char *kSleighSpecInstallDir = "@SLEIGH_SPEC_INSTALL_DIR@";
-static const char *kSleighSpecBuildDir = "@SLEIGH_SPEC_BUILD_DIR@";
+static const char *kSleighSpecInstallDir = "@sleigh_SPEC_INSTALL_DIR@";
+static const char *kSleighSpecBuildDir = "@sleigh_SPEC_BUILD_DIR@";
 
 } // namespace sleigh


### PR DESCRIPTION
While there isn't an official convention, internally CMake uses the case
of the project name in auto-generated variables for the project, like
`<ProjectName>_BINARY_DIR` and `<ProjectName>_DIR`. We should
follow that convention.

closes #50 