### PR TITLE
Let user specify path to sleigh compiler in CMake module

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -35,6 +35,7 @@ jobs:
     - name: Install Linux system dependencies
       if: runner.os == 'Linux'
       run: |
+        sudo apt-get update
         sudo apt-get install -y \
           clang \
           rpm \

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -532,6 +532,7 @@ foreach(spec_file ${spec_file_list})
   # Compile the sla file
   sleigh_compile(
     TARGET "${spec_target}"
+    COMPILER "$<TARGET_FILE:sleigh::sleigh_opt>"
     SLASPEC "${spec_file}"
     LOG_FILE "${spec_build_log}"
     OUT_FILE "${spec_out}"

--- a/cmake/modules/sleighCompile.cmake
+++ b/cmake/modules/sleighCompile.cmake
@@ -11,6 +11,7 @@ cmake_minimum_required(VERSION 3.15)
 # Takes the following required arguments:
 #
 #   TARGET: Named CMake target for performing sleigh compilation
+#   COMPILER: Path to sleigh compiler executable
 #   SLASPEC: Path to slaspec file
 #   LOG_FILE: File to write logs
 #   OUT_FILE: Compiled sleigh output file (should be in build directory somewhere)
@@ -20,7 +21,7 @@ cmake_minimum_required(VERSION 3.15)
 # rebuild the sleigh file then you must delete the OUT_FILE
 function(sleigh_compile)
   set(options)
-  set(oneValueArgs TARGET SLASPEC LOG_FILE OUT_FILE)
+  set(oneValueArgs TARGET COMPILER SLASPEC LOG_FILE OUT_FILE)
   set(multiValueArgs)
   cmake_parse_arguments(parsed
     "${options}"
@@ -54,7 +55,7 @@ function(sleigh_compile)
     MAIN_DEPENDENCY "${spec_file}"
     COMMAND ${CMAKE_COMMAND} -E make_directory "${spec_out_dir}"
     COMMAND ${CMAKE_COMMAND} -E make_directory "${spec_build_log_dir}"
-    COMMAND "$<TARGET_FILE:sleigh::sleigh_opt>" ${spec_file} "${spec_out}" > "${spec_build_log}" 2>&1
+    COMMAND "${parsed_COMPILER}" ${spec_file} "${spec_out}" > "${spec_build_log}" 2>&1
     WORKING_DIRECTORY "${spec_dir}"
     COMMENT "sleigh: Compiling the '${spec_name}' spec file (logs written in '${spec_build_log}')"
     BYPRODUCTS "${spec_build_log}"


### PR DESCRIPTION
This allows user to specify an arbitrary sleigh compiler. Almost always
it's going to be the sleigh::sleigh_opt target, but in the case of
cross-compiling, that won't work because the host won't be able to run
it.

This should enable fixing https://github.com/trailofbits/maat/pull/64. Will wait until it's confirmed that this fixes that issue before merging.

This change is also backwards-incompatible with existing code that uses the function, so it will deserve a (package) version bump.