### PR TITLE
Windows support

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -139,7 +139,8 @@ jobs:
       run: |
         cmake -B build -S . "-Dsleigh_DIR=${{ github.workspace }}/install/lib/cmake/sleigh" -DCMAKE_BUILD_TYPE=${{ matrix.build_type }}
         cmake --build build -j 2 --config ${{ matrix.build_type }}
-        ./build/sleigh_test
+        cd build
+        ctest -V -C ${{ matrix.build_type }}
 
     - name: Create the packages
       run: cmake

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -20,7 +20,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [ubuntu-latest, macos-latest]
+        os: [ubuntu-latest, macos-latest, windows-latest]
         build_type: [RelWithDebInfo, Debug]
         release: [stable, HEAD]
 
@@ -63,6 +63,10 @@ jobs:
           doxygen \
           graphviz
 
+    - name: Install Windows system dependencies
+      if: runner.os == 'Windows'
+      run: choco install ccache
+
     - name: Generate cache key
       id: cache_key
       shell: cmake -P {0}
@@ -94,56 +98,57 @@ jobs:
         # Clear stats before every build
         execute_process(COMMAND ccache -z)
 
+    - name: CMake version
+      run: cmake --version
+
     - name: Configure the project
-      run: |
-        cmake --version
-        cmake \
-          -S . \
-          -B build \
-          -DCMAKE_CXX_COMPILER_LAUNCHER=ccache \
-          -DCMAKE_C_COMPILER_LAUNCHER=ccache \
-          -DCMAKE_BUILD_TYPE=${{ matrix.build_type }} \
-          -Dsleigh_GHIDRA_RELEASE_TYPE=${{ matrix.release }} \
-          -Dsleigh_ENABLE_TESTS=ON \
-          -Dsleigh_ENABLE_EXAMPLES=ON \
-          -Dsleigh_ENABLE_PACKAGING=ON \
-          -Dsleigh_ENABLE_DOCUMENTATION=ON
+      run: cmake
+        -S .
+        -B build
+        -DCMAKE_CXX_COMPILER_LAUNCHER=ccache
+        -DCMAKE_C_COMPILER_LAUNCHER=ccache
+        -DCMAKE_BUILD_TYPE=${{ matrix.build_type }}
+        -Dsleigh_GHIDRA_RELEASE_TYPE=${{ matrix.release }}
+        -Dsleigh_ENABLE_TESTS=ON
+        -Dsleigh_ENABLE_EXAMPLES=ON
+        -Dsleigh_ENABLE_PACKAGING=ON
+        -Dsleigh_ENABLE_DOCUMENTATION=ON
 
     - name: Build the project
-      run: |
-        cmake \
-          --build build \
-          -j 2 \
-          -v
+      run: cmake
+        --build build
+        --config ${{ matrix.build_type }}
+        -j 2
+        -v
 
     - name: Run the tests
-      run: |
-        ( cd build && ctest -V )
+      working-directory: build
+      run: ctest -V -C ${{ matrix.build_type }}
 
     - name: Run the example
-      run: |
-        cmake \
-          --build build \
-          -j 2 \
-          --target sleighexample_runner
+      run: cmake
+        --build build
+        -j 2
+        --config ${{ matrix.build_type }}
+        --target sleighexample_runner
 
     - name: Run the install target
-      run: |
-        cmake --install build \
-          --prefix install
+      run: cmake --install build
+        --config ${{ matrix.build_type }}
+        --prefix install
 
     - name: Test install directory
       working-directory: tests/find_package
       run: |
-        cmake -B build -S . -Dsleigh_DIR=${{ github.workspace }}/install/lib/cmake/sleigh
-        cmake --build build -j 2
+        cmake -B build -S . "-Dsleigh_DIR=${{ github.workspace }}/install/lib/cmake/sleigh" -DCMAKE_BUILD_TYPE=${{ matrix.build_type }}
+        cmake --build build -j 2 --config ${{ matrix.build_type }}
         ./build/sleigh_test
 
     - name: Create the packages
-      run: |
-        cmake \
-          --build build \
-          -j 2 \
+      run: cmake
+          --build build
+          -j 2
+          --config ${{ matrix.build_type }}
           --target package
 
     - name: Test the DEB package
@@ -151,15 +156,12 @@ jobs:
       run: |
         sudo dpkg -i build/*.deb
 
-        cmake \
-          -S tests/find_package \
-          -B find_package_build
-
-        cmake \
-          --build find_package_build -j 2 --verbose
+        cmake -S tests/find_package -B find_package_build -DCMAKE_BUILD_TYPE=${{ matrix.build_type }}
+        cmake --build find_package_build -j 2 --config ${{ matrix.build_type }} --verbose
 
     - name: Locate the packages (RelWithDebInfo only)
       if: matrix.build_type == 'RelWithDebInfo'
+      shell: bash
       id: package_locations
       run: |
         echo ::set-output name=DEB_PACKAGE_PATH::$(ls build/*.deb)

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -122,10 +122,6 @@ jobs:
         -j 2
         -v
 
-    - name: Run the tests
-      working-directory: build
-      run: ctest -V -C ${{ matrix.build_type }}
-
     - name: Run the example
       run: cmake
         --build build
@@ -219,6 +215,15 @@ jobs:
       if: matrix.build_type == 'RelWithDebInfo' && startsWith(github.ref, 'refs/tags/') && matrix.release == 'stable'
       with:
         files: ${{ steps.package_locations.outputs.TGZ_PACKAGE_PATH }}
+
+    # This step is down at the bottom because Windows fails but we still want
+    # to upload the built binaries, regardless. We also want to see if/when
+    # Windows tests start passing or are still failing, so there is no special
+    # handling. GitHub Actions does not support the concept of an allowable
+    # failure state
+    - name: Run the tests
+      working-directory: build
+      run: ctest -V -C ${{ matrix.build_type }}
 
     - name: ccache stats
       run: ccache -s --verbose

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -84,11 +84,12 @@ jobs:
           ${{ steps.cache_key.outputs.VALUE }}_ccache_
 
     - name: Setup ccache
+      working-directory: "${{ github.workspace }}"
       shell: cmake -P {0}
       run: |
-        file(MAKE_DIRECTORY "${{ github.workspace }}/ccache")
-        file(APPEND "$ENV{GITHUB_ENV}" "CCACHE_BASEDIR=${{ github.workspace }}\n")
-        file(APPEND "$ENV{GITHUB_ENV}" "CCACHE_DIR=${{ github.workspace }}/ccache\n")
+        file(MAKE_DIRECTORY "${CMAKE_CURRENT_SOURCE_DIR}/ccache")
+        file(APPEND "$ENV{GITHUB_ENV}" "CCACHE_BASEDIR=${CMAKE_CURRENT_SOURCE_DIR}\n")
+        file(APPEND "$ENV{GITHUB_ENV}" "CCACHE_DIR=${CMAKE_CURRENT_SOURCE_DIR}/ccache\n")
         file(APPEND "$ENV{GITHUB_ENV}" "CCACHE_COMPRESS=true\n")
         # Trial and error to get all files in here
         file(APPEND "$ENV{GITHUB_ENV}" "CCACHE_COMPRESSLEVEL=10\n")

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -273,9 +273,11 @@ add_executable(decomp_opt
 )
 add_executable(sleigh::decomp_opt ALIAS decomp_opt)
 
-target_compile_definitions(decomp_opt PRIVATE
-  __TERMINAL__
-)
+if(NOT CMAKE_HOST_SYSTEM_NAME STREQUAL "Windows")
+  target_compile_definitions(decomp_opt PRIVATE
+    __TERMINAL__
+  )
+endif()
 
 target_link_libraries(decomp_opt PRIVATE
   sleigh::sleigh_settings
@@ -315,9 +317,11 @@ if(sleigh_ENABLE_TESTS)
   )
   target_include_directories(ghidra_test_dbg PRIVATE $<BUILD_INTERFACE:${library_root}>)
 
-  target_compile_definitions(ghidra_test_dbg PRIVATE
-    __TERMINAL__
-  )
+  if(NOT CMAKE_HOST_SYSTEM_NAME STREQUAL "Windows")
+    target_compile_definitions(ghidra_test_dbg PRIVATE
+      __TERMINAL__
+    )
+  endif()
 
   add_test(
     NAME ghidra_unittest_dbg

--- a/cmake/options.cmake
+++ b/cmake/options.cmake
@@ -22,6 +22,11 @@ option(sleigh_DFSVERIFY_DEBUG "Make sure that the block ordering algorithm produ
 option(sleigh_CPUI_STATISTICS "Turn on collection of cover and cast statistics")
 option(sleigh_CPUI_RULECOMPILE "Allow user defined dynamic rules")
 
+# Sanity checking
+if(CMAKE_HOST_SYSTEM_NAME STREQUAL "Windows")
+  set(sleigh_ENABLE_DOCUMENTATION OFF CACHE BOOL "Unsupported on Windows" FORCE)
+endif()
+
 # ---- Warning guard ----
 
 # target_include_directories with the SYSTEM modifier will request the compiler

--- a/include/libsleigh.hh
+++ b/include/libsleigh.hh
@@ -7,10 +7,12 @@
 */
 
 #pragma once
+#ifndef _MSC_VER
 #pragma GCC diagnostic push
 #pragma GCC diagnostic ignored "-Wdeprecated"
 #pragma GCC diagnostic ignored "-Wsign-compare"
 #pragma GCC diagnostic ignored "-Wunused-parameter"
+#endif
 #include "address.hh"
 #include "context.hh"
 #include "emulate.hh"
@@ -33,7 +35,9 @@
 #include "translate.hh"
 #include "types.h"
 #include "xml.hh"
+#ifndef _MSC_VER
 #pragma GCC diagnostic pop
+#endif
 
 #include "Support.h"
 #include "Version.h"

--- a/tests/find_package/CMakeLists.txt
+++ b/tests/find_package/CMakeLists.txt
@@ -20,3 +20,9 @@ target_link_libraries(sleigh_test PRIVATE
   sleigh::decomp
   sleigh::support
 )
+
+include(CTest)
+add_test(
+  NAME smoketest
+  COMMAND sleigh_test
+)

--- a/tools/sleigh-lift/CMakeLists.txt
+++ b/tools/sleigh-lift/CMakeLists.txt
@@ -11,21 +11,6 @@ add_executable(sleigh-lift
 )
 add_executable(sleigh::sleigh-lift ALIAS sleigh-lift)
 
-if(CMAKE_BUILD_TYPE STREQUAL "Debug")
-  if(MSVC)
-    target_compile_options(sleigh-lift PRIVATE
-      /W4
-      /WX
-    )
-  else()
-    target_compile_options(sleigh-lift PRIVATE
-      -Wall
-      -Werror
-      -Wextra
-    )
-  endif()
-endif()
-
 target_link_libraries(sleigh-lift PRIVATE
   sleigh::sla
   sleigh::decomp

--- a/tools/sleigh-lift/src/main.cpp
+++ b/tools/sleigh-lift/src/main.cpp
@@ -261,7 +261,7 @@ int main(int argc, char *argv[]) {
   ContextInternal ctx;
   Sleigh engine(&load_image, &ctx);
   DocumentStorage storage;
-  Element *root = storage.openDocument(*sla_file_path)->getRoot();
+  Element *root = storage.openDocument(sla_file_path->string())->getRoot();
   storage.registerTag(root);
   std::optional<std::filesystem::path> pspec_file_path;
   if (args->pspec_file_name) {
@@ -285,7 +285,7 @@ int main(int argc, char *argv[]) {
     }
   }
   if (pspec_file_path) {
-    Element *pspec_root = storage.openDocument(*pspec_file_path)->getRoot();
+    Element *pspec_root = storage.openDocument(pspec_file_path->string())->getRoot();
     storage.registerTag(pspec_root);
   }
   engine.initialize(storage);

--- a/tools/sleigh-lift/src/main.cpp
+++ b/tools/sleigh-lift/src/main.cpp
@@ -199,10 +199,10 @@ std::optional<LiftArgs> ParseArgs(int argc, char *argv[]) {
       const char *addr_str = argv[arg_index++];
       try {
         addr = std::stoul(addr_str);
-      } catch (const std::invalid_argument &ia) {
+      } catch (const std::invalid_argument &) {
         std::cerr << "Invalid address argument: " << addr_str << std::endl;
         return {};
-      } catch (const std::out_of_range &oor) {
+      } catch (const std::out_of_range &) {
         std::cerr << "Address argument out of range: " << addr_str << std::endl;
         return {};
       }


### PR DESCRIPTION
~Not sure why building with Debug build type fails on Windows.~ Remove compiler warnings as errors

Not sure why tests are failing on Windows also (#92).

After further consideration, I plan to merge this PR even with failing Windows tests. I will open an issue to keep track of it (#92).

I've set some `Required` GitHub Actions tests to pass before merging PRs in the repo's settings, and this excludes the Windows builds, but we should try to remember to check the Windows runs to make sure that at least the build step passes.

closes #6 