### PR TITLE
Fix SLEIGH rebuilds

### DIFF
--- a/cmake/options.cmake
+++ b/cmake/options.cmake
@@ -11,7 +11,8 @@ option(sleigh_ENABLE_EXAMPLES "Set to true to build examples" ON)
 option(sleigh_ENABLE_DOCUMENTATION "Set to true to enable the documentation")
 option(sleigh_ENABLE_PACKAGING "Set to true to enable packaging")
 option(sleigh_ENABLE_SANITIZERS "Set to true to enable sanitizers")
-option(sleigh_ADDITIONAL_PATCHES "The accepted patch format is git patch files, to be applied via git am. The format of the list is a CMake semicolon separated list." "")
+set(sleigh_ADDITIONAL_PATCHES "" CACHE STRING
+  "The accepted patch format is git patch files, to be applied via git am. The format of the list is a CMake semicolon separated list.")
 
 # Internal debug settings
 option(sleigh_OPACTION_DEBUG "Turns on all the action tracing facilities")

--- a/src/setup-ghidra-source.cmake
+++ b/src/setup-ghidra-source.cmake
@@ -39,7 +39,9 @@ else()
   set(ghidra_short_commit "${ghidra_git_tag}")
 endif()
 
-list(APPEND ghidra_patches ${sleigh_ADDITIONAL_PATCHES})
+if(sleigh_ADDITIONAL_PATCHES)
+  list(APPEND ghidra_patches ${sleigh_ADDITIONAL_PATCHES})
+endif()
 
 message(STATUS "Using Ghidra version ${ghidra_version} at git ref ${ghidra_short_commit}")
 

--- a/src/setup-ghidra-source.cmake
+++ b/src/setup-ghidra-source.cmake
@@ -39,9 +39,7 @@ else()
   set(ghidra_short_commit "${ghidra_git_tag}")
 endif()
 
-if(sleigh_ADDITIONAL_PATCHES)
-  list(APPEND ghidra_patches ${sleigh_ADDITIONAL_PATCHES})
-endif()
+list(APPEND ghidra_patches ${sleigh_ADDITIONAL_PATCHES})
 
 message(STATUS "Using Ghidra version ${ghidra_version} at git ref ${ghidra_short_commit}")
 


### PR DESCRIPTION
Avoid generating a `"FALSE"` in the auto-generated cmake, which would make rebuilds fail.