### PR TITLE
Add kSleighFullSpecInstallDir to gDefaultSearchPaths

### DIFF
--- a/support/SpecFilePaths.h.in
+++ b/support/SpecFilePaths.h.in
@@ -11,6 +11,8 @@
 namespace sleigh {
 
 static const char *kSleighSpecInstallDir = "@sleigh_INSTALL_SPECDIR@";
+static const char *kSleighFullSpecInstallDir =
+    "@CMAKE_INSTALL_PREFIX@/@sleigh_INSTALL_SPECDIR@";
 static const char *kSleighSpecBuildDir = "@spec_files_build_dir@";
 
 } // namespace sleigh

--- a/support/Support.cpp
+++ b/support/Support.cpp
@@ -46,7 +46,7 @@ FindSpecFileInSearchPath(std::string_view file_name,
 
 const std::vector<std::filesystem::path> gDefaultSearchPaths = {
     // Derived from the installation
-    kSleighSpecInstallDir,
+    kSleighFullSpecInstallDir,
     // Derived from the build
     kSleighSpecBuildDir,
     // Common install locations


### PR DESCRIPTION
Allows FindSpecFile to succeed if the specfiles are still in the install prefix defined in CMake.