### PR TITLE
Set the git identity before patching

### DIFF
--- a/src/setup-ghidra-source.cmake
+++ b/src/setup-ghidra-source.cmake
@@ -29,9 +29,15 @@ set(ghidra_shallow TRUE)
 set(sleigh_ADDITIONAL_PATCHES "" CACHE STRING
   "The accepted patch format is git patch files, to be applied via git am. The format of the list is a CMake semicolon separated list.")
 
+# See this thread for more details https://github.community/t/github-actions-bot-email-address/17204/5
+set(ghidra_patch_user "github-actions[bot]")
+set(ghidra_patch_email "41898282+github-actions[bot]@users.noreply.github.com")
+
 # pinned stable patches list
 set(ghidra_patches
-  PATCH_COMMAND "${GIT_EXECUTABLE}" am --ignore-space-change --ignore-whitespace --no-gpg-sign
+  PATCH_COMMAND "${GIT_EXECUTABLE}" config user.name "${ghidra_patch_user}" &&
+  "${GIT_EXECUTABLE}" config user.email "${ghidra_patch_email}" &&
+  "${GIT_EXECUTABLE}" am --ignore-space-change --ignore-whitespace --no-gpg-sign
   "${CMAKE_CURRENT_LIST_DIR}/patches/stable/0001-Small-improvements-to-C-decompiler-testing-from-CLI.patch"
   "${CMAKE_CURRENT_LIST_DIR}/patches/stable/0002-Add-include-guards-to-decompiler-C-headers.patch"
   "${CMAKE_CURRENT_LIST_DIR}/patches/stable/0003-Fix-UBSAN-errors-in-decompiler.patch"
@@ -48,7 +54,9 @@ if("${sleigh_RELEASE_TYPE}" STREQUAL "HEAD")
   set(ghidra_git_tag "${ghidra_head_git_tag}")
   set(ghidra_shallow FALSE)
   set(ghidra_patches
-    PATCH_COMMAND "${GIT_EXECUTABLE}" am --ignore-space-change --ignore-whitespace --no-gpg-sign
+    PATCH_COMMAND "${GIT_EXECUTABLE}" config user.name "${ghidra_patch_user}" &&
+    "${GIT_EXECUTABLE}" config user.email "${ghidra_patch_email}" &&
+    "${GIT_EXECUTABLE}" am --ignore-space-change --ignore-whitespace --no-gpg-sign
     "${CMAKE_CURRENT_LIST_DIR}/patches/HEAD/0001-Small-improvements-to-C-decompiler-testing-from-CLI.patch"
     "${CMAKE_CURRENT_LIST_DIR}/patches/HEAD/0002-Add-include-guards-to-decompiler-C-headers.patch"
     "${CMAKE_CURRENT_LIST_DIR}/patches/HEAD/0003-Fix-UBSAN-errors-in-decompiler.patch"


### PR DESCRIPTION
When using sleigh as a dependency it fails in the GitHub Actions pipeline with an error like this:

```
HEAD is now at 9c724c1a Merge remote-tracking branch 'origin/GP-2355_AARCH64_thunk_pattern' into patch
[2/9] Performing update step for 'ghidrasource-populate'
[3/9] Performing patch step for 'ghidrasource-populate'

Committer identity unknown

*** Please tell me who you are.

Run

  git config --global user.email "you@example.com"
  git config --global user.name "Your Name"

to set your account's default identity.
Omit --global to set the identity only in this repository.

fatal: empty ident name (for <runner@xxx>) not allowed
FAILED: ghidrasource-populate-prefix/src/ghidrasource-populate-stamp/ghidrasource-populate-patch
```

For now I just set it the same as in [main.yml](https://github.com/lifting-bits/sleigh/blob/master/.github/workflows/main.yml), but let me know if there should be some logic there. Perhaps it should only set the identity if there is none set globally or something...