### PR TITLE
CI: Specifically use macos-12 image

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -20,7 +20,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [ubuntu-latest, macos-latest, windows-latest]
+        os: [ubuntu-latest, macos-12, windows-latest]
         build_type: [RelWithDebInfo, Debug]
         release: [stable, HEAD]
 


### PR DESCRIPTION
macos-latest now points to Apple Silicon macos-14 image, which is causing some tests to fail.