### PR TITLE
Update Ghidra HEAD to commit ec59e407b

### DIFF
--- a/src/setup-ghidra-source.cmake
+++ b/src/setup-ghidra-source.cmake
@@ -52,7 +52,7 @@ if("${sleigh_RELEASE_TYPE}" STREQUAL "HEAD")
   # TODO: CMake only likes numeric characters in the version string....
   set(ghidra_head_version "11.3")
   set(ghidra_version "${ghidra_head_version}")
-  set(ghidra_head_git_tag "2333ab6111a5fac503960bfddb069d6009ba21ad")
+  set(ghidra_head_git_tag "ec59e407bf88a9b60f430f4934cd56a021c5c219")
   set(ghidra_git_tag "${ghidra_head_git_tag}")
   set(ghidra_shallow FALSE)
   set(ghidra_patches


### PR DESCRIPTION
Changed files:

```
M       Ghidra/Features/Decompiler/src/decompile/cpp/condexe.cc
M       Ghidra/Features/Decompiler/src/decompile/cpp/condexe.hh
M       Ghidra/Features/Decompiler/src/decompile/cpp/coreaction.cc
M       Ghidra/Features/Decompiler/src/decompile/cpp/funcdata.hh
M       Ghidra/Features/Decompiler/src/decompile/cpp/funcdata_block.cc
M       Ghidra/Features/Decompiler/src/decompile/cpp/funcdata_op.cc
M       Ghidra/Features/Decompiler/src/decompile/cpp/op.cc
M       Ghidra/Features/Decompiler/src/decompile/cpp/op.hh
M       Ghidra/Features/Decompiler/src/decompile/cpp/ruleaction.cc
M       Ghidra/Features/Decompiler/src/decompile/cpp/ruleaction.hh
M       Ghidra/Features/Decompiler/src/decompile/cpp/subflow.cc
M       Ghidra/Features/Decompiler/src/decompile/cpp/typeop.cc
M       Ghidra/Features/Decompiler/src/decompile/cpp/varnode.cc
M       Ghidra/Features/Decompiler/src/decompile/cpp/varnode.hh
A       Ghidra/Features/Decompiler/src/decompile/datatests/ccmp.xml
M       Ghidra/Processors/68000/data/languages/68000.ldefs
M       Ghidra/Processors/AARCH64/data/languages/AARCH64.ldefs
M       Ghidra/Processors/AARCH64/data/languages/AARCH64_swift.cspec
M       Ghidra/Processors/ARM/data/languages/ARM.ldefs
M       Ghidra/Processors/Loongarch/data/languages/loongarch.ldefs
M       Ghidra/Processors/MIPS/data/languages/mips.ldefs
M       Ghidra/Processors/PowerPC/data/languages/ppc.ldefs
M       Ghidra/Processors/RISCV/data/languages/riscv.ldefs
M       Ghidra/Processors/Sparc/data/languages/SparcV9.ldefs
M       Ghidra/Processors/SuperH4/data/languages/SuperH4.ldefs
M       Ghidra/Processors/Xtensa/data/languages/xtensa.ldefs
M       Ghidra/Processors/x86/data/languages/x86-64-swift.cspec
M       Ghidra/Processors/x86/data/languages/x86.ldefs
```