### PR TITLE
Bump Ghidra HEAD commit 2ec84c2fb

### DIFF
--- a/src/setup-ghidra-source.cmake
+++ b/src/setup-ghidra-source.cmake
@@ -52,7 +52,7 @@ if("${sleigh_RELEASE_TYPE}" STREQUAL "HEAD")
   # TODO: CMake only likes numeric characters in the version string....
   set(ghidra_head_version "11.4")
   set(ghidra_version "${ghidra_head_version}")
-  set(ghidra_head_git_tag "21382506445918f49516512e7332f47c3cceba05")
+  set(ghidra_head_git_tag "bb4853e414f0030880428059b3a8c94a817017d9")
   set(ghidra_git_tag "${ghidra_head_git_tag}")
   set(ghidra_shallow FALSE)
   set(ghidra_patches

--- a/src/setup-ghidra-source.cmake
+++ b/src/setup-ghidra-source.cmake
@@ -52,7 +52,7 @@ if("${sleigh_RELEASE_TYPE}" STREQUAL "HEAD")
   # TODO: CMake only likes numeric characters in the version string....
   set(ghidra_head_version "11.4")
   set(ghidra_version "${ghidra_head_version}")
-  set(ghidra_head_git_tag "bb4853e414f0030880428059b3a8c94a817017d9")
+  set(ghidra_head_git_tag "2ec84c2fb4fdfec3eb8ff710f325179beb23bc8a")
   set(ghidra_git_tag "${ghidra_head_git_tag}")
   set(ghidra_shallow FALSE)
   set(ghidra_patches

--- a/src/setup-ghidra-source.cmake
+++ b/src/setup-ghidra-source.cmake
@@ -50,9 +50,9 @@ set(ghidra_patches
 if("${sleigh_RELEASE_TYPE}" STREQUAL "HEAD")
   # TODO: Try to remember to look at Ghidra/application.properties
   # TODO: CMake only likes numeric characters in the version string....
-  set(ghidra_head_version "11.3")
+  set(ghidra_head_version "11.4")
   set(ghidra_version "${ghidra_head_version}")
-  set(ghidra_head_git_tag "cfffcf0c13f168a99a53a11a66f6304360e5cbee")
+  set(ghidra_head_git_tag "21382506445918f49516512e7332f47c3cceba05")
   set(ghidra_git_tag "${ghidra_head_git_tag}")
   set(ghidra_shallow FALSE)
   set(ghidra_patches


### PR DESCRIPTION
Changed files:

```
M       Ghidra/Features/Decompiler/src/decompile/cpp/fspec.cc
M       Ghidra/Features/Decompiler/src/decompile/cpp/fspec.hh
M       Ghidra/Features/Decompiler/src/decompile/cpp/funcdata.hh
M       Ghidra/Features/Decompiler/src/decompile/cpp/funcdata_block.cc
M       Ghidra/Features/Decompiler/src/decompile/cpp/funcdata_op.cc
M       Ghidra/Features/Decompiler/src/decompile/cpp/ghidra_translate.cc
M       Ghidra/Features/Decompiler/src/decompile/cpp/ghidra_translate.hh
M       Ghidra/Features/Decompiler/src/decompile/cpp/marshal.cc
M       Ghidra/Features/Decompiler/src/decompile/cpp/modelrules.cc
M       Ghidra/Features/Decompiler/src/decompile/cpp/modelrules.hh
M       Ghidra/Features/Decompiler/src/decompile/cpp/pcoderaw.cc
M       Ghidra/Features/Decompiler/src/decompile/cpp/pcoderaw.hh
M       Ghidra/Features/Decompiler/src/decompile/cpp/ruleaction.cc
M       Ghidra/Features/Decompiler/src/decompile/cpp/ruleaction.hh
M       Ghidra/Features/Decompiler/src/decompile/cpp/rulecompile.hh
M       Ghidra/Features/Decompiler/src/decompile/cpp/sleighbase.cc
M       Ghidra/Features/Decompiler/src/decompile/cpp/sleighbase.hh
M       Ghidra/Features/Decompiler/src/decompile/cpp/translate.cc
M       Ghidra/Features/Decompiler/src/decompile/cpp/translate.hh
M       Ghidra/Features/Decompiler/src/decompile/unittests/testmarshal.cc
M       Ghidra/Processors/ARM/data/languages/ARMneon.sinc
M       Ghidra/Processors/x86/data/languages/avx.sinc
M       Ghidra/Processors/x86/data/languages/avx512.sinc
M       Ghidra/Processors/x86/data/languages/avx512_manual.sinc
M       Ghidra/Processors/x86/data/languages/cet.sinc
M       Ghidra/Processors/x86/data/languages/ia.sinc
M       Ghidra/Processors/x86/data/languages/x86.ldefs
```