### PR TITLE
Improve Ghidra update process with commit details and dry run mode

### DIFF
--- a/.github/workflows/update_head.yml
+++ b/.github/workflows/update_head.yml
@@ -49,6 +49,10 @@ jobs:
           Changed files:
 
           ${{ steps.head_update.outputs.changed_files }}
+
+          Commit details:
+
+          ${{ steps.head_update.outputs.commit_details }}
         branch: cron/update-ghidra-${{ steps.head_update.outputs.short_sha }}
         delete-branch: true
         token: ${{ steps.generate-token.outputs.token }}


### PR DESCRIPTION
Add detailed commit information to the Ghidra HEAD update process:
- Display information about each commit affecting sleigh files
- Include these commit details in GitHub Action PR descriptions
- Add --dry-run flag to preview changes without modifying files
- Improve output formatting and error handling

Also reformat with ruff