### PR TITLE
Set core.longpaths while patching

### DIFF
--- a/src/setup-ghidra-source.cmake
+++ b/src/setup-ghidra-source.cmake
@@ -37,6 +37,7 @@ set(ghidra_patch_email "41898282+github-actions[bot]@users.noreply.github.com")
 set(ghidra_patches
   PATCH_COMMAND "${GIT_EXECUTABLE}" config user.name "${ghidra_patch_user}" &&
   "${GIT_EXECUTABLE}" config user.email "${ghidra_patch_email}" &&
+  "${GIT_EXECUTABLE}" config core.longpaths true &&
   "${GIT_EXECUTABLE}" am --ignore-space-change --ignore-whitespace --no-gpg-sign
   "${CMAKE_CURRENT_LIST_DIR}/patches/stable/0001-Fix-UBSAN-errors-in-decompiler.patch"
   "${CMAKE_CURRENT_LIST_DIR}/patches/stable/0002-Use-stroull-instead-of-stroul-to-parse-address-offse.patch"


### PR DESCRIPTION
The Ghidra source code has very long paths and without this setting you get error messages and the patching fails if you do not clone it very high up the tree. This setting has no effect on Linux/mac.

```
[7/7] Completed 'sleigh-populate'
-- Using Ghidra version 10.3 at git ref 80ccdad
-- Populating ghidrasource
-- Configuring done (0.1s)
-- Generating done (0.0s)
-- Build files have been written to: C:/CodeBlocks/Dna/Dna.LLVMInterop/dependencies/build/remill-prefix/src/remill-build/_deps/ghidrasource-subbuild
Ghidra/Debug/Debugger-agent-dbgmodel/src/main/java/agent/dbgmodel/impl/dbgmodel/datamodel/script/debug/DataModelScriptDebugBreakpointEnumeratorInternal.java: Filename too long
Ghidra/Debug/Debugger-agent-dbgmodel/src/main/java/agent/dbgmodel/impl/dbgmodel/datamodel/script/debug/DataModelScriptDebugVariableSetEnumeratorImpl.java: Filename too long
Ghidra/Debug/Debugger-agent-dbgmodel/src/main/java/agent/dbgmodel/impl/dbgmodel/datamodel/script/debug/DataModelScriptDebugVariableSetEnumeratorInternal.java: Filename too long
Ghidra/Debug/Debugger-agent-dbgmodel/src/main/java/agent/dbgmodel/jna/dbgmodel/datamodel/script/debug/WrapIDataModelScriptDebugVariableSetEnumerator.java: Filename too long
Ghidra/Features/PDB/src/main/java/ghidra/app/util/bin/format/pdb2/pdbreader/symbol/AbstractManagedLocalOrParameterRelativeToAlternateFramePointerMsSymbol.java: Filename too long
GhidraBuild/EclipsePlugins/GhidraDev/GhidraDevPlugin/src/main/java/ghidradev/ghidraprojectcreator/preferences/GhidraProjectCreatorPreferenceInitializer.java: Filename too long
GhidraBuild/EclipsePlugins/GhidraDev/GhidraDevPlugin/src/main/java/ghidradev/ghidraprojectcreator/wizards/pages/ConfigureGhidraModuleProjectWizardPage.java: Filename too long
GhidraBuild/EclipsePlugins/GhidraDev/GhidraDevPlugin/src/main/java/ghidradev/ghidraprojectcreator/wizards/pages/ConfigureGhidraScriptProjectWizardPage.java: Filename too long
Warning: you are leaving 15 commits behind, not connected to
any of your branches:

  e00e6c124d ia
  b1b16157d4 quicciii
  bb2cc057a2 ppc_vle
  f0bf1313cc ppc_isa
... and 11 more.

HEAD is now at 80ccdadeba Merge remote-tracking branch 'origin/GP-2563_SplitVarnodesBasedOnDatatype' (Closes #3884)
D       Ghidra/Debug/Debugger-agent-dbgmodel/src/main/java/agent/dbgmodel/impl/dbgmodel/datamodel/script/debug/DataModelScriptDebugBreakpointEnumeratorInternal.java
D       Ghidra/Debug/Debugger-agent-dbgmodel/src/main/java/agent/dbgmodel/impl/dbgmodel/datamodel/script/debug/DataModelScriptDebugVariableSetEnumeratorImpl.java
D       Ghidra/Debug/Debugger-agent-dbgmodel/src/main/java/agent/dbgmodel/impl/dbgmodel/datamodel/script/debug/DataModelScriptDebugVariableSetEnumeratorInternal.java
D       Ghidra/Debug/Debugger-agent-dbgmodel/src/main/java/agent/dbgmodel/jna/dbgmodel/datamodel/script/debug/WrapIDataModelScriptDebugVariableSetEnumerator.java
D       Ghidra/Features/PDB/src/main/java/ghidra/app/util/bin/format/pdb2/pdbreader/symbol/AbstractManagedLocalOrParameterRelativeToAlternateFramePointerMsSymbol.java
D       GhidraBuild/EclipsePlugins/GhidraDev/GhidraDevPlugin/src/main/java/ghidradev/ghidraprojectcreator/preferences/GhidraProjectCreatorPreferenceInitializer.java
D       GhidraBuild/EclipsePlugins/GhidraDev/GhidraDevPlugin/src/main/java/ghidradev/ghidraprojectcreator/wizards/pages/ConfigureGhidraModuleProjectWizardPage.java
D       GhidraBuild/EclipsePlugins/GhidraDev/GhidraDevPlugin/src/main/java/ghidradev/ghidraprojectcreator/wizards/pages/ConfigureGhidraScriptProjectWizardPage.java
No stash entries found.
error: unable to create file
Ghidra/Debug/Debugger-agent-dbgmodel/src/main/java/agent/dbgmodel/impl/dbgmodel/datamodel/script/debug/DataModelScriptDebugBreakpointEnumeratorInternal.java: Filename too long
error: unable to create file
Ghidra/Debug/Debugger-agent-dbgmodel/src/main/java/agent/dbgmodel/impl/dbgmodel/datamodel/script/debug/DataModelScriptDebugVariableSetEnumeratorImpl.java: Filename too long
error: unable to create file
Ghidra/Debug/Debugger-agent-dbgmodel/src/main/java/agent/dbgmodel/impl/dbgmodel/datamodel/script/debug/DataModelScriptDebugVariableSetEnumeratorInternal.java: Filename too long
error: unable to create file
Ghidra/Debug/Debugger-agent-dbgmodel/src/main/java/agent/dbgmodel/jna/dbgmodel/datamodel/script/debug/WrapIDataModelScriptDebugVariableSetEnumerator.java: Filename too long
error: unable to create file
Ghidra/Features/PDB/src/main/java/ghidra/app/util/bin/format/pdb2/pdbreader/symbol/AbstractManagedLocalOrParameterRelativeToAlternateFramePointerMsSymbol.java: Filename too long
error: unable to create file
GhidraBuild/EclipsePlugins/GhidraDev/GhidraDevPlugin/src/main/java/ghidradev/ghidraprojectcreator/preferences/GhidraProjectCreatorPreferenceInitializer.java: Filename too long
error: unable to create file
GhidraBuild/EclipsePlugins/GhidraDev/GhidraDevPlugin/src/main/java/ghidradev/ghidraprojectcreator/wizards/pages/ConfigureGhidraModuleProjectWizardPage.java: Filename too long
error: unable to create file
GhidraBuild/EclipsePlugins/GhidraDev/GhidraDevPlugin/src/main/java/ghidradev/ghidraprojectcreator/wizards/pages/ConfigureGhidraScriptProjectWizardPage.java: Filename too long
fatal: Could not reset index file to revision 'HEAD'.
No stash entries found.
error: unable to create file
Ghidra/Debug/Debugger-agent-dbgmodel/src/main/java/agent/dbgmodel/impl/dbgmodel/datamodel/script/debug/DataModelScriptDebugBreakpointEnumeratorInternal.java: Filename too long
error: unable to create file
Ghidra/Debug/Debugger-agent-dbgmodel/src/main/java/agent/dbgmodel/impl/dbgmodel/datamodel/script/debug/DataModelScriptDebugVariableSetEnumeratorImpl.java: Filename too long
error: unable to create file
Ghidra/Debug/Debugger-agent-dbgmodel/src/main/java/agent/dbgmodel/impl/dbgmodel/datamodel/script/debug/DataModelScriptDebugVariableSetEnumeratorInternal.java: Filename too long
error: unable to create file
Ghidra/Debug/Debugger-agent-dbgmodel/src/main/java/agent/dbgmodel/jna/dbgmodel/datamodel/script/debug/WrapIDataModelScriptDebugVariableSetEnumerator.java: Filename too long
error: unable to create file
Ghidra/Features/PDB/src/main/java/ghidra/app/util/bin/format/pdb2/pdbreader/symbol/AbstractManagedLocalOrParameterRelativeToAlternateFramePointerMsSymbol.java: Filename too long
error: unable to create file
GhidraBuild/EclipsePlugins/GhidraDev/GhidraDevPlugin/src/main/java/ghidradev/ghidraprojectcreator/preferences/GhidraProjectCreatorPreferenceInitializer.java: Filename too long
error: unable to create file
GhidraBuild/EclipsePlugins/GhidraDev/GhidraDevPlugin/src/main/java/ghidradev/ghidraprojectcreator/wizards/pages/ConfigureGhidraModuleProjectWizardPage.java: Filename too long
error: unable to create file
GhidraBuild/EclipsePlugins/GhidraDev/GhidraDevPlugin/src/main/java/ghidradev/ghidraprojectcreator/wizards/pages/ConfigureGhidraScriptProjectWizardPage.java: Filename too long
fatal: Could not reset index file to revision 'e00e6c124d580fd3738f8ed08f8ebe2a16e6e5fe'.
No stash entries found.
CMake Error at
C:/CodeBlocks/Dna/Dna.LLVMInterop/dependencies/build/remill-prefix/src/remill-build/_deps/ghidrasource-subbuild/ghidrasource-populate-prefix/tmp/ghidrasource-populate-g
itupdate.cmake:301 (message):

  Failed to unstash changes in:
  'C:/CodeBlocks/Dna/Dna.LLVMInterop/dependencies/build/remill-prefix/src/remill-build/_deps/ghidrasource-src'.

  You will have to resolve the conflicts manually

[0/7] Performing update step for 'ghidrasource-populate'
FAILED: ghidrasource-populate-prefix/src/ghidrasource-populate-stamp/ghidrasource-populate-update
C:/CodeBlocks/Dna/Dna.LLVMInterop/dependencies/build/remill-prefix/src/remill-build/_deps/ghidrasource-subbuild/ghidrasource-populate-prefix/src/ghidrasource-populate-s
tamp/ghidrasource-populate-update
C:\WINDOWS\system32\cmd.exe /C "cd /D C:\CodeBlocks\Dna\Dna.LLVMInterop\dependencies\build\remill-prefix\src\remill-build_deps\ghidrasource-src && "C:\Program
Files\CMake\bin\cmake.exe" -Dcan_fetch=YES -DCMAKE_MESSAGE_LOG_LEVEL=VERBOSE -P
C:/CodeBlocks/Dna/Dna.LLVMInterop/dependencies/build/remill-prefix/src/remill-build/_deps/ghidrasource-subbuild/ghidrasource-populate-prefix/tmp/ghidrasource-populate-g
itupdate.cmake"
ninja: build stopped: subcommand failed.
```